### PR TITLE
printing list object as one string for list-like properties

### DIFF
--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -107,6 +107,8 @@ class Column(object):
                 ret = vm
                 for attrseg in self._attr.split('.'):
                     ret = getattr(ret, attrseg)
+                    if hasattr(ret, '__iter__') and not isinstance(ret, str):
+                        ret = ' '.join(map(str, ret))
             elif isinstance(self._attr, collections.abc.Callable):
                 ret = self._attr(vm)
 


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/9007 print tags list as one string instead of object.